### PR TITLE
Add message property to access APIError message.

### DIFF
--- a/alpaca/common/exceptions.py
+++ b/alpaca/common/exceptions.py
@@ -16,6 +16,11 @@ class APIError(Exception):
     def code(self):
         error = json.loads(self._error)
         return error["code"]
+    
+    @property
+    def message(self):
+        error = json.loads(self._error)
+        return error["message"]
 
     @property
     def status_code(self):


### PR DESCRIPTION
Access de message of an error for debugging purposes with this new property for the APIError class.